### PR TITLE
Put jQuery available globally through expose-loader Webpack plugin

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "dependencies": {
+    "expose-loader": "^0.7.5",
     "jquery": "^3.2.1",
     "jquery-datepicker": "^1.11.5",
     "jquery-ui": "^1.12.1",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -16,6 +16,13 @@ module.exports = {
   module: {
     rules: [
       {
+        test: require.resolve('jquery'),
+        use: [{
+          loader: 'expose-loader',
+          options: '$'
+        }]
+      },
+      {
         test: /\.js$/,
         exclude: /node_modules/,
         loader: 'babel-loader',

--- a/yarn.lock
+++ b/yarn.lock
@@ -1351,6 +1351,10 @@ expand-range@^1.8.1:
   dependencies:
     fill-range "^2.1.0"
 
+expose-loader@^0.7.5:
+  version "0.7.5"
+  resolved "https://registry.yarnpkg.com/expose-loader/-/expose-loader-0.7.5.tgz#e29ea2d9aeeed3254a3faa1b35f502db9f9c3f6f"
+
 express@^4.13.3:
   version "4.15.2"
   resolved "https://registry.yarnpkg.com/express/-/express-4.15.2.tgz#af107fc148504457f2dca9a6f2571d7129b97b35"


### PR DESCRIPTION
Hi @backpackerhh 

This PR, which was made after read [a comment on a similar issue](https://github.com/fronteed/icheck/issues/322#issuecomment-285145200), tries to be a solution for the [problem described at StackOverflow](https://stackoverflow.com/questions/43803192/is-not-defined-within-a-js-erb-view-using-webpack-2-in-rails-app).

Hopefully, it is enough to solve it :) avoiding to do [weird things](https://stackoverflow.com/questions/43803192/is-not-defined-within-a-js-erb-view-using-webpack-2-in-rails-app#comment82013999_43803192) like 


```ruby
<%= render file: 'node_modules/jquery/dist/jquery.min.js' %>
```

:innocent::innocent::innocent: 

